### PR TITLE
feat: validate pull request format

### DIFF
--- a/.github/workflows/conventional-commit.yaml
+++ b/.github/workflows/conventional-commit.yaml
@@ -1,0 +1,20 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Using the https://www.conventionalcommits.org spec, validate the format of commit messages in a pull request.
Uses https://github.com/amannn/action-semantic-pull-request to run a github workflow.